### PR TITLE
ci: update workflow to use haskell-actions organization for actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - uses: haskell-actions/setup@v1
+      - uses: haskell-actions/setup@v2
         with:
           enable-stack: true
-      - uses: haskell-actions/hlint-setup@v1
+      - uses: haskell-actions/hlint-setup@v2
         with:
           version: "3.1.6"
-      - uses: haskell-actions/hlint-run@v1
+      - uses: haskell-actions/hlint-run@v2
         with:
           path: .
           fail-on: warning

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-      - uses: haskell/actions/setup@v1
+      - uses: haskell-actions/setup@v1
         with:
           enable-stack: true
-      - uses: haskell/actions/hlint-setup@v1
+      - uses: haskell-actions/hlint-setup@v1
         with:
           version: "3.1.6"
-      - uses: haskell/actions/hlint-run@v1
+      - uses: haskell-actions/hlint-run@v1
         with:
           path: .
           fail-on: warning

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os:
+          - macOS-13
+          - ubuntu-24.04
+          - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
- Switches from haskell/actions to haskell-actions for setup and hlint steps
- Ensures workflow uses maintained and correct action sources
